### PR TITLE
Duplicating weekly stats, and other

### DIFF
--- a/PSForever_Stats_MVP/index.php
+++ b/PSForever_Stats_MVP/index.php
@@ -141,9 +141,10 @@
         return 0;
     }
     
-    $get = file_get_contents($url, false, null, 0, $char_limit);
+                                                    //  Getting only so many indices ignores many characters
+    $get = file_get_contents($url, false, null, 0); //$char_limit);
     $len = strlen($get);
-    for ($i = 0; $i < 1000; $i++) 
+    for ($i = 0; $i < $len; $i++) 
     {
         $json = json_decode($get . ']}', true);
         if ($json != null) 
@@ -153,13 +154,16 @@
         $get = substr($get, 0, $len--);
     }
 
-    $len = sizeof($json['players']);
+    $total_len = sizeof($json['players']);
+    $len = $total_len;
+    //  Using $len here instead of $total_len ignored anyone that is not within the top [50] already
+    /*
     if ($len > 50) 
     {
         $len = 50;
-    }
+    }*/
     //  Table and stats initialize
-    for ($i = 0; $i < $len; $i++) 
+    for ($i = 0; $i < $total_len; $i++) 
     {
         $name    = $json['players'][$i]['name'];
         $faction = (int)$json['players'][$i]['faction_id'];
@@ -187,7 +191,7 @@
     //  Get unique stat per index from JSON
     function get_unique_stat($link, $json)
     {
-        $len = 50;
+        $len = sizeof($json['players']);
         $array = [$len];
         $db_current = "db_current";
         $db_weekly = "db_weekly";
@@ -314,7 +318,7 @@
     if ($_array[0] != "")
     {
         $display = "table-row";
-        $output = output_string($_array, $len);
+        $output = output_string($_array, $total_len);
     }
     require_once("index.html");
 ?>

--- a/PSForever_Stats_MVP/index.php
+++ b/PSForever_Stats_MVP/index.php
@@ -4,8 +4,9 @@
     $ip = $file_get['ipaddress'];
     $username = $file_get['username'];
     $password = $file_get['password'];
-    $db_current = $file_get['database'] . "_current";
-    $db_weekly = $file_get['database'] . "_weekly";
+    $database =  $file_get['database'];
+    $db_current = "db_current";
+    $db_weekly = "db_weekly";
     $table_weekly = "table_weekly_stats";
     $table_current = "table_current_stats";
     $url = 'https://play.psforever.net/api/char_stats_cep/0';
@@ -14,7 +15,7 @@
     $flag_manual_weekly_reset = false;
 
     mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
-    $link = mysqli_connect($ip, "root", "", "mysql");
+    $link = mysqli_connect($ip, $username, $password, $database);
     function create_event($minute)
     {                                                                                                
         // Starts on the beginning of a Monday to give time for those interested in viewing stats during the weekend


### PR DESCRIPTION
Was checking $len and num_row values and learned they were the wrong checks. So in effect this time I fixed the logic. This stops duplicating entries in weekly_stats, and then compares properly throughout the week. 

Not much else, though set the new timings for the events to be at based on 00:00 on Monday mostly giving more time for views during the weekend.